### PR TITLE
Fixes relatives paths for "Program Files" to use environement variables

### DIFF
--- a/manifests/windows_host_scripts/plink.cmd
+++ b/manifests/windows_host_scripts/plink.cmd
@@ -1,6 +1,6 @@
 @echo off
-set defpath="\Program Files\PuTTy"
-set defpath_x64="\Program Files (x86)\PuTTy"
+set defpath="%ProgramFiles%\PuTTy"
+set defpath_x64="%ProgramFiles(x86)%\PuTTy"
 
 set keyfile=insecure_putty_key.ppk
 set port=2222

--- a/manifests/windows_host_scripts/putty_scp.cmd
+++ b/manifests/windows_host_scripts/putty_scp.cmd
@@ -1,6 +1,6 @@
 @echo off
-set defpath="\Program Files\PuTTy"
-set defpath_x64="\Program Files (x86)\PuTTy"
+set defpath="%ProgramFiles%\PuTTy"
+set defpath_x64="%ProgramFiles(x86)%\PuTTy"
 
 set keyfile=insecure_putty_key.ppk
 set port=2222

--- a/manifests/windows_host_scripts/putty_ssh.cmd
+++ b/manifests/windows_host_scripts/putty_ssh.cmd
@@ -1,6 +1,6 @@
 @echo off
-set defpath="\Program Files\PuTTy"
-set defpath_x64="\Program Files (x86)\PuTTy"
+set defpath="%ProgramFiles%\PuTTy"
+set defpath_x64="%ProgramFiles(x86)%\PuTTy"
 
 set keyfile=insecure_putty_key.ppk
 set port=2222


### PR DESCRIPTION
Fixes a bug where script had to be run on the same drive as "Program Files" due to relative paths. Now uses the appropriate environment variables