### PR TITLE
prevent Vagrant from creating new ssh keys when creating the virtual machine

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,7 +7,7 @@ UI_OPTIONS = "standalone --password=admin"
 
 Vagrant.configure("2") do |config|
     config.vm.box = "ubuntu/xenial32"
-#    config.ssh.insert_key = false
+    config.ssh.insert_key = false
 
     config.vm.network :forwarded_port, guest: 8080, host: 8080
 


### PR DESCRIPTION
This should fix https://github.com/plone/plonedev.vagrant/issues/23